### PR TITLE
fix: install libkeybinder/libnotify in tarball smoke test

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -623,9 +623,17 @@ jobs:
         run: |
           sudo apt-get update
           # GTK + GL + the host GStreamer stack audioplayers_linux loads at
-          # startup. libmpv is intentionally omitted: the tarball must supply it.
+          # startup, plus the two GTK-ecosystem libs AppFlowy hard-NEEDs at
+          # launch (libkeybinder for global hotkeys, libnotify for tray/
+          # notifications). These are host-provided, exactly like libgtk-3-0:
+          # the .deb declares them in Depends and the AppImage lists them under
+          # include, so they're never bundled. Omitting them here aborts the
+          # loader on libkeybinder-3.0.so.0 before the libmpv gate is reached.
+          # libmpv is the ONLY lib intentionally omitted: the tarball must
+          # supply it.
           sudo apt-get install -y --no-install-recommends \
             xvfb libgtk-3-0 libgl1 libegl1 \
+            libkeybinder-3.0-0 libnotify4 \
             libgstreamer1.0-0 libgstreamer-plugins-base1.0-0 \
             gstreamer1.0-plugins-base gstreamer1.0-plugins-good
 


### PR DESCRIPTION
The tarball-smoke-test job launched ./AppFlowy/AppFlowy on a bare ubuntu-24.04 that had libgtk-3-0 but not libkeybinder-3.0-0, so the dynamic loader aborted at startup (exit 127) on libkeybinder-3.0.so.0 before the libmpv self-containment gate was ever reached.

These are host-provided GTK-ecosystem libs (the .deb declares them in Depends and the AppImage lists them under include), so install them in the test alongside libgtk-3-0. libmpv stays the sole deliberate omission so the self-containment gate remains meaningful.