### PR TITLE
fix(linux): re-package AppImage with new runtime to remove libfuse2 dependency

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -444,6 +444,32 @@ jobs:
             # appimage-builder emits AppFlowy-<version>-x86_64.AppImage in CWD
             # (frontend), which is exactly where the upload step looks.
             ls -la AppFlowy-*-x86_64.AppImage
+
+            # Re-package with the new appimagetool to remove libfuse2 dependency.
+            # The old appimage-builder v1.1.0 uses an outdated runtime that requires
+            # libfuse2. The new appimagetool downloads the latest type2-runtime
+            # with FUSE 3 built-in, so end users no longer need libfuse2.
+            # See: https://github.com/AppFlowy-IO/AppFlowy/issues/8967
+            APPIMAGE_BUILT=$(ls AppFlowy-*-x86_64.AppImage | head -n1)
+            if [ -n "$APPIMAGE_BUILT" ]; then
+              echo "🔄 Re-packaging AppImage with new runtime (no libfuse2)..."
+              # Extract the AppDir from the old AppImage
+              APPIMAGE_EXTRACT_AND_RUN=1 "$APPIMAGE_BUILT" --appimage-extract
+              rm -f "$APPIMAGE_BUILT"
+              # Download appimagetool (latest, uses type2-runtime with FUSE 3)
+              APPIMAGETOOL="./appimagetool-x86_64.AppImage"
+              if [ ! -x "$APPIMAGETOOL" ]; then
+                wget -q -O "$APPIMAGETOOL" \
+                  https://github.com/AppImage/appimagetool/releases/latest/download/appimagetool-x86_64.AppImage
+                chmod +x "$APPIMAGETOOL"
+              fi
+              # Re-package — the new runtime has FUSE 3 built-in
+              ARCH=x86_64 APPIMAGE_EXTRACT_AND_RUN=1 \
+                "$APPIMAGETOOL" squashfs-root "$APPIMAGE_BUILT"
+              rm -rf squashfs-root
+              echo "✅ AppImage re-packaged without libfuse2 dependency"
+              ls -la "$APPIMAGE_BUILT"
+            fi
           else
             echo "⚠️ AppImage build failed, but continuing..."
             # Create a dummy AppImage file to prevent upload failures


### PR DESCRIPTION
## Summary

Adds a post-build repackaging step that extracts the AppImage created by `appimage-builder` and re-packages it with the new `appimagetool` (which uses the latest type2-runtime with **FUSE 3 built-in**). This eliminates the `libfuse2` dependency at runtime.

**This is a minimal fix** — the existing `appimage-builder` logic is fully preserved. Only a ~20-line repackaging step is added after the build.

## Problem

The current AppImage is built with `appimage-builder` v1.1.0, which produces AppImages that depend on `libfuse2`. Modern Linux distributions (Ubuntu 24.04+, Fedora 40+) ship FUSE 3 by default and do not include `libfuse2`, causing:

```
dlopen(): error loading libfuse.so.2
AppImages require FUSE to run.
```

## Solution

After `appimage-builder` creates the AppImage:
1. Extract the AppDir with `--appimage-extract`
2. Download the new `appimagetool` (latest release)
3. Re-package with the new runtime (FUSE 3 built-in)
4. Clean up

## Changes

- `.github/workflows/linux.yaml`: Added repackaging step (~20 lines) after the existing `appimage-builder` build

## Testing

The existing `appimage-smoke-test` job already uses `APPIMAGE_EXTRACT_AND_RUN=1`, so it will continue to work. The produced AppImage will now work on systems without `libfuse2` installed.

## References

- Fixes [AppFlowy-IO/AppFlowy#8967](https://github.com/AppFlowy-IO/AppFlowy/issues/8967)
- [AppImage FUSE wiki](https://github.com/AppImage/AppImageKit/wiki/Fuse)
- [appimagetool](https://github.com/AppImage/appimagetool)

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>